### PR TITLE
Move leftover files to data/archive directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 def_local_env
 prof_library
 *_env
-data/*/*
 config/.env
 config/config.pl
 config/.netrc
@@ -9,6 +8,7 @@ config/.netrc
 zephir_full_daily_a*
 *.gz
 local
+local*
 *_stderr
 *.debug
 *rights_rpt.tsv
@@ -21,3 +21,4 @@ local
 test_*
 compare_*
 *.jsonl
+*.json

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ A mostly haphazard collection of scripts (Bash, Perl) that take Zephir records, 
 
 Parts of these should likely be extracted into their own repositories, or obviated by a re-architecture. 
 
-#todo: needs to be replaced in multiple files
-
 
 run_hathi_volumes_ingested_zephir.sh (daily)
 ====================================
@@ -21,7 +19,7 @@ This takes the new barcodes from ingest (feed) and sends them to Zephir. Zephir 
 
 Data In
 --------
-* barcodes_YYY-MM-DD_ (previously: /exlibris/aleph/uprod/miu50/local/mdp/return/) Now picked up directly at /htapps/babel/feed/var/rights/archive ?
+* barcodes_YYY-MM-DD_ (previously: /exlibris/aleph/uprod/miu50/local/mdp/return/) Now picked up directly at /htapps/babel/feed/var/rights
 
 Data Out
 --------

--- a/cleanup_directory.sh
+++ b/cleanup_directory.sh
@@ -1,0 +1,18 @@
+# random report files
+mv *_rpt.txt data/report_archive
+mv *_report.txt data/report_archive
+
+# dollar_dup files
+mv *dollar_dup* data/dollar_dup_archive/
+
+# vufind_removed_cids
+mv vufind_removed_cids* data/removed_cids_archive/
+
+# ht_bib_export_incr
+mv ht_bib_export_incr* data/ht_bib_export_incr_archive/
+
+# zephir_upd_*
+mv zephir_upd_* data/zephir_upd_archive/
+
+# zephir_full_*
+mv zephir_full_* data/zephir_full_archive/


### PR DESCRIPTION
Lots of data files get left behind in the root directory. At some point I need to go through and decide which can be safely 'rm' at the end of the days process and which need to be saved. In the mean time, stick them in some data/*_archive directories for future review. 