### PR TITLE
silence rightsdb/zeph downloads, htfile processing

### DIFF
--- a/bld_rights_db.pl
+++ b/bld_rights_db.pl
@@ -53,7 +53,7 @@ my $access_profile_code;
 print "entering fetch loop\n";
 while ( my ($id, $namespace, $attr_num, $reason_num, $source_num, $timestamp, $note, $access_profile_num) = $sdr_sth->fetchrow_array() ) {
   $incnt++;
-  print STDERR "processing $incnt\n" if $incnt % 100000 == 0;
+  # print STDERR "processing $incnt\n" if $incnt % 100000 == 0;
   $id =~ s/\s+$//;
   $attr_code = $attribute_codes->{$attr_num};
   $source_code = $source_codes->{$source_num};

--- a/ftpslib/ftps_zephir_get
+++ b/ftpslib/ftps_zephir_get
@@ -15,5 +15,5 @@ SERVER=ftps.cdlib.org
 echo "server: ${SERVER}, remote file: ${remote_file}, local_file: ${local_file}"
 #/l/local/bin/curl -n -k --ftp-ssl --ftp-pasv  ftp://${SERVER}/${remote_file} --out ${local_file}
 
-curl --netrc-file $conf --ssl-reqd --ftp-pasv  ftp://${SERVER}/${remote_file} --out ${local_file}
+curl -s --netrc-file $conf --ssl-reqd --ftp-pasv  ftp://${SERVER}/${remote_file} --out ${local_file}
 

--- a/run_zephir_full_daily.sh
+++ b/run_zephir_full_daily.sh
@@ -85,14 +85,14 @@ done
 echo "`date`: wait for zephir_hathifile processes to end" >> $REPORT_FILE
 while :
 do
-  echo "`date` sleeping......"
+  #echo "`date` sleeping......"
   sleep 60
   alldone=true
   for file in $file_list; do
     rpt=${file}_stderr
     last_line=`tail -1 $rpt`
     if [ "$last_line" != "DONE" ]; then
-      echo "last line from $rpt is $last_line"
+      #echo "last line from $rpt is $last_line"
       alldone=false
     fi
   done


### PR DESCRIPTION
Curl was printing out a progress meter which was polluting the daily report emails. 

Downloading the rightsdb was doing similarly. 

Processing the full hathifile each day was also printing out an update on how many lines had been processed every 60 seconds. 

All this reporting hid the important bits, so I commented them out. 