### PR TITLE
HT-1346 make pd-pvt items access:deny

### DIFF
--- a/zephir_hathifile.pl
+++ b/zephir_hathifile.pl
@@ -899,7 +899,7 @@ sub clean_json_line {
 
 sub rights_map {
   my $attr = shift;
-  $attr =~ /^(pd|world|ic-world|cc|und-world)/ and return 'allow';
+  $attr =~ /^(pdus$|pd$|world|ic-world|cc|und-world)/ and return 'allow';
   return 'deny';
 }
 


### PR DESCRIPTION
attr =~ /^(pd|world|ic-world|cc|und-world)/ and return 'allow';
is now
attr =~ /^(pdus$|pd$|world|ic-world|cc|und-world)/ and return 'allow';

