### PR TITLE
postZephir was not using the rights db file

### DIFF
--- a/postZephir.pm
+++ b/postZephir.pm
@@ -140,8 +140,6 @@ sub main {
   print OUT_RPT "processing file $infile\n";
 
   my $rightsDB = rightsDB->new();
-  my $rights_sub = '';
-  my %RIGHTS;
   if ($rights_db_file) {
     print "using dbm file $rights_db_file for rights determination\n";
     print OUT_RPT "using dbm file $rights_db_file for rights determination\n";

--- a/t/test_full_file.sh
+++ b/t/test_full_file.sh
@@ -1,0 +1,1 @@
+docker-compose run --rm pz perl postZephir.pm -i ht_bib_export_incr_2022-06-09.json.gz -o test_output -f t/fixtures/rights_dbm -z -r test_rights_output -d


### PR DESCRIPTION
postZephir typically dumps rights information to a giant hash for fast lookup while figuring out what has changed. Direct DB connection is possible, but historically we haven't used it.

The use of the rights database file was failing. See line 41, 143/144, and `sub GetRightsDBM` where it is actually used. Removing 143/144 means GetRightsDBM should work now. 

I added `t/test_full_file.sh` which I already had locally, but had not committed because it depends upon an ht_bib_export file and the 2GB rights db file. Smarter fixtures are likely possible, but not right now. 

I confirmed that t/test_full_file.sh was not finding old rights in the rights file, something I should have noticed in the test reports. With the fix, it is now finding the appropriate information. 