### PR TITLE
Copy full file to $CATALOG_PREP

### DIFF
--- a/run_zephir_full_daily.sh
+++ b/run_zephir_full_daily.sh
@@ -108,7 +108,7 @@ if [ $DAY == "01" ]; then
     echo "$message" | mailx -s"error in $SCRIPTNAME" $EMAIL
   fi
   echo "`date`: sending full file to hathi trust catalog solr server" 
-  cp ${ZEPHIR_DATA}/full/zephir_full_${YESTERDAY}_vufind.json.gz $CATALOG_PREP
+  cp zephir_full_${YESTERDAY}_vufind.json.gz $CATALOG_PREP
   cmdstatus=$?
   if [ $cmdstatus != "0" ]; then
     message="Problem transferring file to $CATALOG_PREP is $cmdstatus"


### PR DESCRIPTION
The code to move the full file to $CATALOG_PREP and $CATALOG_ARCHIVE used to both work because the `cwd` happend to match the parent of $ZEPHIR_DATA. The move to k8s included changing the working directory to $TMPDIR, breaking the copy to $CATALOG_PREP.

This just changes the source file location for the copy for $CATALOG_PREP to `cwd`, same as for $CATALOG_ARCHIVE.