### PR TITLE
Reviewed and updated the template build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,45 +1,51 @@
-name: Build A Branch
+name: Build
 
 on:
-  workflow_run:
-    workflows: ['Run Tests']
-    branches: ['main']
-    types: [completed]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: Release or Tag
-        required: true
-      push_latest:
-        description: Set True if the build is for the latest version
-        type: boolean
-        required: false
-        default: false
+    workflow_run:
+        workflows: ['Run Tests']
+        branches: ['main']
+        types: [completed]
+
+    workflow_dispatch:
+        inputs:
+            img_tag:
+                description: Docker Image Tag
+            ref:
+                description: Revision or Branch to build
+                default: main
+            push_latest:
+                description: Set True if the build is for the latest version
+                type: boolean
+                required: false
+                default: false
+            platforms:
+                description: Platforms to build for
+                type: choice
+                default: linux/amd64,linux/arm64
+                options:
+                - linux/amd64,linux/arm64
+                - linux/amd64
+                - linux/arm64
+            rebuild:
+                description: Rebuild this image?
+                type: boolean
+                default: false
 
 jobs:
-  build-image:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    build-image:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
 
-    steps:
-      - name: Set Inputs
-        id: set_inputs
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_run" ]; then
-            echo "tag=${{ github.sha }}" >> $GITHUB_ENV
-            echo "push_latest=true" >> $GITHUB_ENV
-          else
-              # workflow_dispatch or other trigger
-              echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
-              echo "push_latest=${{ github.event.inputs.push_latest }}" >> $GITHUB_ENV
-          fi 
-      
-      - name: Build Image
-        uses: hathitrust/github_actions/build@v1
-        with:
-          image: ghcr.io/${{ github.repository }}-unstable
-          tag: ${{ env.tag }}
-          push_latest: ${{ env.push_latest}}
-          registry_token: ${{ github.token }}
+        steps:
+            - name: Build Image
+              uses: hathitrust/github_actions/build@v1.4.0
+              with:
+                image: ghcr.io/${{ github.repository }}-unstable
+                dockerfile: Dockerfile
+                img_tag: ${{ inputs.img_tag }}
+                tag: ${{ inputs.ref }}
+                push_latest: ${{ inputs.push_latest}}
+                registry_token: ${{ github.token }}
+                rebuild: ${{ inputs.rebuild }}


### PR DESCRIPTION
This update consists of a few more manual options that allow us to pass a dedicated docker container image tag as well as rebuild an image and select a platform to build for. Some logic was removed from this template and placed in the shared build action allowing this yaml file to be more straight forward. 