### PR TITLE
Fix baked-in assumption about location of RIGHTS_ARCHIVE

### DIFF
--- a/lib/derivatives.rb
+++ b/lib/derivatives.rb
@@ -8,33 +8,29 @@ module PostZephirProcessing
   # file dates to fetch for processing.
   class Derivatives
     # Location data for the derivatives we care about when constructing our list of missing dates.
-    # A file that has multiple locations (rights vs rights_archive) need only exist in one
-    # of them.
-    # TODO: is it even necessary to consider RIGHTS_DIR any more? Rights files can be expected to
-    # be in rights_archive by the time any workflow step that uses this class executes.
     DIR_DATA = {
       zephir_full: {
-        locations: [:CATALOG_PREP],
+        location: :CATALOG_PREP,
         pattern: /^zephir_full_(\d{8})_vufind\.json\.gz$/,
         full: true
       },
       zephir_full_rights: {
-        locations: [:RIGHTS_DIR, :RIGHTS_ARCHIVE],
+        location: :RIGHTS_ARCHIVE,
         pattern: /^zephir_full_(\d{8})\.rights$/,
         full: true
       },
       zephir_update: {
-        locations: [:CATALOG_PREP],
+        location: :CATALOG_PREP,
         pattern: /^zephir_upd_(\d{8})\.json\.gz$/,
         full: false
       },
       zephir_update_rights: {
-        locations: [:RIGHTS_DIR, :RIGHTS_ARCHIVE],
+        location: :RIGHTS_ARCHIVE,
         pattern: /^zephir_upd_(\d{8})\.rights$/,
         full: false
       },
       zephir_update_delete: {
-        locations: [:CATALOG_PREP],
+        location: :CATALOG_PREP,
         pattern: /^zephir_upd_(\d{8})_delete\.txt\.gz$/,
         full: false
       }
@@ -67,8 +63,6 @@ module PostZephirProcessing
       case location.to_sym
       when :CATALOG_PREP
         ENV["CATALOG_PREP"] || "/htsolr/catalog/prep/"
-      when :RIGHTS_DIR
-        ENV["RIGHTS_DIR"] || "/htapps/babel/feed/var/rights"
       when :RIGHTS_ARCHIVE
         ENV["RIGHTS_ARCHIVE"] || "/htapps/babel/feed/var/rights/archive"
       end
@@ -76,24 +70,14 @@ module PostZephirProcessing
 
     # Run regexp against the contents of dir and store matching files
     # that have datestamps in the period of interest.
-    # Do the same for the archive directory if it exists.
-    # Does not attempt to iterate nonexistent directory.
     # @return [Array<Date>] de-duped and sorted ASC
     def directory_inventory(name:)
-      inventory_dates = []
-      directories_named(name: name).each do |dir|
-        next unless File.directory? dir
-
-        inventory_dates += Dir.children(dir)
-          .filter_map { |filename| (m = DIR_DATA[name][:pattern].match(filename)) && Date.parse(m[1]) }
-          .select { |date| dates.all_dates.include? date }
-      end
-      inventory_dates.sort.uniq
-    end
-
-    # Given a name like :zephir_full, return an Array with the associated paths
-    def directories_named(name:)
-      DIR_DATA[name][:locations].map { |loc| directory_for(location: loc) }
+      dir = directory_for(location: DIR_DATA[name][:location])
+      Dir.children(dir)
+        .filter_map { |filename| (m = DIR_DATA[name][:pattern].match(filename)) && Date.parse(m[1]) }
+        .select { |date| dates.all_dates.include? date }
+        .sort
+        .uniq
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,8 @@ end
 
 # Set the all-important SPEC_TMPDIR and derivative env vars,
 # and populate test dir with the appropriate directories.
+# FIXME: RIGHTS_DIR should no longer be needed for testing Derivatives,
+# and may not be needed for testing Verifier and friends.
 def setup_test_dirs(parent_dir:)
   ENV["SPEC_TMPDIR"] = parent_dir
   ENV["CATALOG_PREP"] = catalog_prep_dir

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,7 @@ def rights_dir
 end
 
 def rights_archive_dir
-  File.join(ENV["SPEC_TMPDIR"], "rights", "archive")
+  File.join(ENV["SPEC_TMPDIR"], "rights_archive")
 end
 
 # Set the all-important SPEC_TMPDIR and derivative env vars,
@@ -39,6 +39,7 @@ def setup_test_dirs(parent_dir:)
   ENV["SPEC_TMPDIR"] = parent_dir
   ENV["CATALOG_PREP"] = catalog_prep_dir
   ENV["RIGHTS_DIR"] = rights_dir
+  ENV["RIGHTS_ARCHIVE"] = rights_archive_dir
   [catalog_prep_dir, rights_dir, rights_archive_dir].each do |loc|
     Dir.mkdir loc
   end


### PR DESCRIPTION
- `Derivatives` class no longer derives the archive path based on a flag in the data.
- Elevates `RIGHTS_ARCHIVE` to a "known location" with a reasonable default.