### PR TITLE
Pin `progress_tracker` to version 0.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 # Install perl modules that we cannot get with apt-get
 RUN cpanm --notest \
     Devel::Cover::Report::Coveralls \
-    https://github.com/hathitrust/progress_tracker.git@v0.10.0
+    https://github.com/hathitrust/progress_tracker.git@v0.11.0
 
 # Ruby setup
 ENV BUNDLE_PATH /gems


### PR DESCRIPTION
- This is for `JOB_NAMESPACE`s to keep Argo workflow test vs prod from clobbering each other