### PR TITLE
Fix off-by-one error in linecount comparison between hathifile and it…

### DIFF
--- a/lib/verifier/hathifiles.rb
+++ b/lib/verifier/hathifiles.rb
@@ -30,9 +30,16 @@ module PostZephirProcessing
         path = derivative.path
         next unless verify_file(path: path)
         contents_verifier = verify_hathifile_contents(path: path)
-        catalog_path = Derivative::CatalogArchive.new(date: date - 1, full: derivative.full).path
+        catalog_path = catalog_source(hathifile: derivative).path
         verify_hathifile_linecount(contents_verifier.line_count, catalog_path: catalog_path)
       end
+    end
+
+    # The post-Zephir catalog whence the hathifile was derived
+    # @param hathifile [Derivative::Hathifile]
+    # @return [Derivative::CatalogArchive]
+    def catalog_source(hathifile:)
+      Derivative::CatalogArchive.new(date: hathifile.date, full: hathifile.full)
     end
 
     def verify_hathifile_linecount(linecount, catalog_path:)

--- a/spec/unit/verifier/hathifiles_spec.rb
+++ b/spec/unit/verifier/hathifiles_spec.rb
@@ -54,5 +54,13 @@ module PostZephirProcessing
         expect_not_ok(:verify_hathifile_contents, contents, errmsg: /.*columns.*/, gzipped: true)
       end
     end
+
+    describe "#catalog_source" do
+      it "has the correct datestamp" do
+        hathifile_derivative = Derivative::Hathifile.new(date: Date.today, full: false)
+        catalog_derivative = described_class.new.catalog_source(hathifile: hathifile_derivative)
+        expect(catalog_derivative.datestamp).to eq(hathifile_derivative.datestamp - 1)
+      end
+    end
   end
 end


### PR DESCRIPTION
…s source catalog

- The hathifiles verifier was written when derivative dates were file datestamps
  - The source zephir file datestamp was calculated as the hathifile minus one day
  - After the datestamp delta logic was added to the derivative classes, this "minus one" should have been removed
- This patch adds and exposes a `catalog_source` method for testability