### PR TITLE
Accept more HTIDs

### DIFF
--- a/lib/verifier/post_zephir.rb
+++ b/lib/verifier/post_zephir.rb
@@ -153,7 +153,7 @@ module PostZephirProcessing
     # * exist & be be readable (both covered by verify_rights)
     # * either be empty, or all its lines must match regex.
     def verify_rights_file_format(path:)
-      line_regex = /^ [a-z0-9]+ \. [a-z0-9:\/\$\.]+ # col 1, namespace.objid
+      line_regex = /^ [a-z0-9]+ \. \S+ # col 1, namespace.objid
               \t (ic|pd|pdus|und)              # col 2, one of these
               \t bib                           # col 3, exactly this
               \t bibrights                     # col 4, exactly this

--- a/spec/unit/verifier/post_zephir_spec.rb
+++ b/spec/unit/verifier/post_zephir_spec.rb
@@ -351,13 +351,24 @@ module PostZephirProcessing
 
       volids_not_ok = ["", "x", "x.", ".x", "X.X"]
       volids_not_ok.each do |bad_volume_id|
-        it "rejects a file with malformed volume id" do
+        it "rejects a file with malformed volume id #{bad_volume_id}" do
           rights_cols[0] = bad_volume_id
 
           expect_not_ok(
             :verify_rights_file_format,
             rights_cols.join("\t"),
             errmsg: /invalid column id/
+          )
+        end
+      end
+
+      ["uiuc.0001_001_001", "uc1.$b123456", "miun.aaa0001.001.001", "ucbk.ark:/28722/h2b854467"].each do |ok_volume_id|
+        it "accepts a file with non-alphanumeric htid #{ok_volume_id}" do
+          rights_cols[0] = ok_volume_id
+
+          expect_ok(
+            :verify_rights_file_format,
+            rights_cols.join("\t")
           )
         end
       end


### PR DESCRIPTION
Ingest does extensive validation of htids, so we don't necessarily need to do that here as well. This was rejecting uiuc IDs with underscores; rather than adding underscore to the regex, just accept any non-empty HTID.