### PR TITLE
ETT-239 Broken "Old pdus/gfv volumes no longer VIEW_FULL" Report

### DIFF
--- a/bin/grin_gfv.pl
+++ b/bin/grin_gfv.pl
@@ -163,6 +163,7 @@ close($fh);
 unless ($noop) {
     # Send the second email and we're done
     $mailer = new_mailer("Old pdus/gfv volumes no longer VIEW_FULL");
+    print $mailer "$email_body";
     $mailer->close() or warn("Couldn't send message: $!");
 }
 


### PR DESCRIPTION
- Reporter noted "empty email with no results."
- This is the second e-mail sent by `bin/grin_gfv.pl`.
- Email body was being reinitialized and populated but not `print`ed to the `Mail::Mailer` object.
- The oversight appears to originate in the migration of rights code from `feed_internal`.

Reviewer: there are no tests for this change. Please inspect single-line addition.
(I note the email body variable need not be in double quotes, tried it both ways and decided to keep the quoted version consistent with line 95.)