### PR TITLE
 Better placement of Dockerfile COPY phase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ FROM ruby:3.4
 ENV ROOTDIR /usr/src/app
 ENV HOME /usr/src/app
 
-COPY . $ROOTDIR
-WORKDIR $ROOTDIR
-
 # Install Debian packages
 RUN apt-get update && apt-get install -y \
     bsd-mailx \
@@ -43,5 +40,8 @@ ENV RUBYLIB /usr/src/app/lib
 RUN gem install bundler --version "~> 2.5.23"
 RUN bundle config --global silence_root_warning 1
 RUN bundle install
+
+COPY . $ROOTDIR
+WORKDIR $ROOTDIR
 
 CMD run_process_zephir_incremental.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,14 +34,14 @@ RUN cpanm --notest \
     Devel::Cover::Report::Coveralls \
     https://github.com/hathitrust/progress_tracker.git@v0.11.1
 
+COPY . $ROOTDIR
+WORKDIR $ROOTDIR
+
 # Ruby setup
 ENV BUNDLE_PATH /gems
 ENV RUBYLIB /usr/src/app/lib
 RUN gem install bundler --version "~> 2.5.23"
 RUN bundle config --global silence_root_warning 1
 RUN bundle install
-
-COPY . $ROOTDIR
-WORKDIR $ROOTDIR
 
 CMD run_process_zephir_incremental.sh


### PR DESCRIPTION
- Restore Dockerfile change that moves the `COPY` phase from near the beginning to near the end of file.
- Change got lost in the shuffle and left out of first periodic maintenance PR.