### PR TITLE
ETT-519, ETT-520 modify pdus/gfv reports

### DIFF
--- a/bin/new_grin_gfv.pl
+++ b/bin/new_grin_gfv.pl
@@ -1,0 +1,117 @@
+#!/usr/bin/env perl
+
+# Does things in 2 steps.
+# Each step consists of running a set of queries,
+# and sending an email about what was done.
+#
+# Step 1:
+# Updates ic/bib and und/bib rows to pdus/gfv in rights_current
+# if they have viewability 'VIEW_FULL' GRIN and are not marked as CLAIMED and are not Keio.
+# CLAIMED items are items with the CLAIMED flag is set, items where the rights holder has given permission
+# to Google to make the item VIEW_FULL. That permission does not extend to HathiTrust.
+# We don't do it for Keio because there are items that are PD in Japan that are not PD in the US (e.g. icus)
+
+# Step 2:
+# Updates pdus/gfv rows in rights_current records
+# with their previous attr&reason
+# if they no longer have viewability 'VIEW_FULL' in GRIN.
+
+use strict;
+use warnings;
+
+use lib "$ENV{ROOTDIR}/perl_lib";
+
+use Date::Manip qw(ParseDate UnixDate);
+use Getopt::Long;
+use Mail::Mailer;
+use ProgressTracker;
+use YAML::XS;
+
+use Database;
+use grin_gfv;
+
+my $noop         = undef; # set with --noop
+my $mailer       = undef;
+
+# config
+my $config_dir   = $ENV{CONFIG_DIR} || '/usr/src/app/config';
+my $config_yaml  = "$config_dir/rights.yml";
+my $config       = YAML::XS::LoadFile($config_yaml);
+my $rights_dir   = $config->{rights}->{rights_dir};
+
+GetOptions(
+    # skip update queries, emails, log file & tracker
+    'noop=s' => \$noop,
+);
+
+#### Step 1: UPDATE ITEMS TO FULL VIEW ####
+my $tracker = ProgressTracker->new();
+$tracker->start_stage("set_pdus_gfv") unless $noop;
+
+my $grin_gfv = grin_gfv->new;
+my $updates = $grin_gfv->updates_to_gfv;
+
+# Loop over the relevant items and update their attr/reason
+foreach my $update (@$updates) {
+    unless ($noop) {
+        $grin_gfv->write_update_to_gfv($update);
+        $tracker->inc();
+    }
+}
+
+# Send first email
+unless ($noop) {
+    $mailer = new_mailer("New ic/und but VIEW_FULL volumes");
+    print $mailer $grin_gfv->updates_to_gfv_report;
+    $mailer->close() or warn("Couldn't send message: $!");
+}
+
+#### Step 2: REVERT FORMERLY VIEW_FULL ITEMS ####
+$tracker->start_stage("revert_pdus_gfv") unless $noop;
+
+# Open file for which to record reverted barcodes
+my $barcode_log = sprintf(
+    '%s/barcodes_%s_revert_gfv_feed',
+    $rights_dir,
+    UnixDate(ParseDate("now"), '%Y-%m-%d_%H-%M-%S')
+);
+open(my $fh, ">>", $barcode_log) or die("can't open $barcode_log: $!");
+
+my $reversions = $grin_gfv->reversions_from_gfv;
+foreach my $reversion (@$reversions) {
+    unless ($noop) {
+        print $fh "$reversion->{namespace}.$reversion->{id}\n";
+        # update item in rights_current with the old attr/reason
+        $grin_gfv->write_reversion_from_gfv($reversion);
+        $tracker->inc();
+    }
+}
+close($fh);
+
+unless ($noop) {
+    # Send the second email and we're done
+    $mailer = new_mailer("Old pdus/gfv volumes no longer VIEW_FULL");
+    print $mailer $grin_gfv->reversions_from_gfv_report;
+    $mailer->close() or warn("Couldn't send message: $!");
+}
+
+$tracker->finalize() unless $noop;
+
+# The 2 emails sent only differ in subject and body,
+# so we can do everything else using the same template.
+sub new_mailer {
+    my $subject = shift;
+    my $mailer  = new Mail::Mailer;
+    my $to_addr = join(
+        ', ',
+        split(' ', $ENV{'TO_ADDRESSES'})
+    );
+
+    my $email = {
+        'From'    => $ENV{'FROM_ADDRESS'},
+        'Subject' => $subject,
+        'To'      => $to_addr
+    };
+
+    $mailer->open($email);
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     command: prove
 
   mariadb:
-    image: ghcr.io/hathitrust/db-image:latest
+    image: ghcr.io/hathitrust/db-image:updates_aug_2025
     volumes:
       - ./sql/ingest.sql:/docker-entrypoint-initdb.d/999-ingest.sql
       - ./sql/hathifiles.sql:/docker-entrypoint-initdb.d/999-hathifiles.sql

--- a/perl_lib/Database.pm
+++ b/perl_lib/Database.pm
@@ -1,5 +1,9 @@
 package Database;
 
+use strict;
+use warnings;
+use utf8;
+
 # Shared utility for read-only connection to Rights DB (via views in ht database)
 # or, for populate_rights_data.pl, read-write access to the Rights DB directly.
 

--- a/perl_lib/grin_gfv.pm
+++ b/perl_lib/grin_gfv.pm
@@ -1,0 +1,222 @@
+package grin_gfv;
+
+use strict;
+use warnings;
+use utf8;
+
+use POSIX qw(strftime);
+
+# Day Mo NN XX:YY:ZZ Year
+our $REPORT_TIME_FORMAT = "%a %b %e %T %Y";
+
+my $UPDATE_USER   = 'libadm';
+# For rights_current update ($write_update_to_gfv_sql)
+my $GFV_ATTR_ID   = 9;  # pdus
+my $GFV_REASON_ID = 12; # gfv
+# For rights_current reversion update
+my $REVERSION_NOTE = 'Revert to previous attr/reason; no longer VIEW_FULL';
+
+
+# This gets us the items to update in update_gfv.
+my $select_updates_to_gfv_sql = <<~'SQL';
+  SELECT r.namespace, r.id, a.name
+  FROM rights_current     r
+  INNER JOIN attributes   a ON r.attr   = a.id
+  INNER JOIN reasons      e ON r.reason = e.id
+  INNER JOIN ht.feed_grin g ON r.id     = g.id AND r.namespace = g.namespace
+  WHERE g.viewability = 'VIEW_FULL' AND a.name IN ('ic', 'und') AND e.name = 'bib' AND g.claimed != 'true' AND r.namespace != 'keio'
+  ORDER BY r.namespace, r.id
+SQL
+
+my $select_reversions_from_gfv_sql = <<~'SQL';
+  SELECT r.namespace, r.id
+  FROM rights_current r
+  INNER JOIN ht.feed_grin g ON r.id = g.id AND r.namespace = g.namespace
+  WHERE r.reason='12' AND (g.viewability != 'VIEW_FULL' OR g.claimed = 'true' OR r.namespace = 'keio')
+  ORDER BY r.namespace, r.id
+SQL
+
+my $select_rights_log_sql = <<~'SQL';
+  SELECT attr, reason, source
+  FROM rights_log
+  WHERE namespace = ? AND id = ?
+  ORDER BY time DESC
+SQL
+
+my $write_update_to_gfv_sql = <<~SQL;
+  UPDATE rights_current
+  SET
+    attr   = $GFV_ATTR_ID,
+    reason = $GFV_REASON_ID,
+    time   = CURRENT_TIMESTAMP,
+    user   = '$UPDATE_USER'
+  WHERE namespace = ? AND id = ?
+SQL
+
+my $write_reversion_from_gfv_sql = <<~SQL;
+  UPDATE rights_current
+  SET
+    attr   = ?,
+    reason = ?,
+    time   = CURRENT_TIMESTAMP,
+    user   = '$UPDATE_USER',
+    note   = '$REVERSION_NOTE'
+  WHERE namespace = ? AND id = ?
+SQL
+
+sub new {
+  my ($class, %args) = @_;
+  my $self = bless {}, $class;
+  my $dbh = Database::get_rights_rw_dbh;
+  $self->{dbh} = $dbh;
+  $self->{select_updates_to_gfv_sth} = $dbh->prepare($select_updates_to_gfv_sql) || die "could not prepare query: $select_updates_to_gfv_sql";;
+  $self->{select_reversions_from_gfv_sth} = $dbh->prepare($select_reversions_from_gfv_sql) || die "could not prepare query: $select_reversions_from_gfv_sql";
+  $self->{select_rights_log_sth} = $dbh->prepare($select_rights_log_sql) || die "could not prepare query: $select_rights_log_sql";
+  $self->{write_update_to_gfv_sth} = $dbh->prepare($write_update_to_gfv_sql) || die "could not prepare query: $write_update_to_gfv_sql";
+  $self->{write_reversion_from_gfv_sth} = $dbh->prepare($write_reversion_from_gfv_sql) || die "could not prepare query: $write_reversion_from_gfv_sql";
+  return $self;
+}
+
+# ic/und items that should nonetheless be pdus/gfv according to GRIN
+# Returns an arrayref of hashref, sorted by namespace and id
+# Each hashref contains the fields {namespace, id, attr}
+# e.g. { namespace => 'mdp', id => '001', attr => 'ic' }
+sub updates_to_gfv {
+  my $self = shift;
+
+  my $updates = [];
+  my $sth = $self->{select_updates_to_gfv_sth};
+  $sth->execute or die $sth->errstr;
+  while (my $row = $sth->fetch) {
+    my ($namespace, $id, $attr) = @$row;
+    push @$updates, {namespace => $namespace, id => $id, attr => $attr};
+  }
+  $sth->finish;
+  return $updates;
+}
+
+# Extract updates_to_gfv data into e-mail report
+# Optional date_string keyword arg is for testing
+sub updates_to_gfv_report {
+  my $self    = shift;
+  my $updates = shift;
+  my %args    = @_;
+
+  my $date_string = $args{date_string} || strftime($REPORT_TIME_FORMAT, localtime);
+  my $report = sprintf "%d volumes set to pdus/gfv at $date_string\n\n", scalar @$updates;
+  my $ic_section = "IC\n\n";
+  my $und_section = "UND\n\n";
+  foreach my $update (@$updates) {
+    if ($update->{attr} eq 'ic') {
+      $ic_section .= "$update->{namespace}.$update->{id}\n";
+    } elsif ($update->{attr} eq 'und') {
+      $und_section .= "$update->{namespace}.$update->{id}\n";
+    } else {
+      printf STDERR "ERROR: unknown attribute in %s\n", Dumper($update);
+    }
+  }
+  $report .= $ic_section . "\n";
+  $report .= $und_section;
+  return $report;
+}
+
+# Write a pdus/gfv update (one of the hashrefs from updates_to_gfv) to the Rights DB
+sub write_update_to_gfv {
+  my $self   = shift;
+  my $update = shift;
+
+  $self->{write_update_to_gfv_sth}->execute(
+    $update->{namespace},
+    $update->{id}
+  );
+}
+
+# pdus_gfv items that should be reverted to bib rights
+# Returns an arrayref of hashref, sorted by namespace, id
+# Each hashref contains the fields {namespace, id, attr, reason, source, gfv_count}
+# e.g. { namespace => 'mdp', id => '001', attr => 5, reason => 8, source => 1, gfv_count => 0 }
+# NOTE, the attr/reason/src are NUMERIC this time
+sub reversions_from_gfv {
+  my $self = shift;
+
+  my $updates = [];
+  my $sth = $self->{select_reversions_from_gfv_sth};
+  $sth->execute or die $sth->errstr;
+  while (my $row = $sth->fetch) {
+    my ($namespace, $id) = @$row;
+    my $rights_log_data = $self->_rights_log_data($namespace, $id);
+    push @$updates, {
+      namespace => $namespace,
+      id => $id,
+      attr => $rights_log_data->{attr},
+      reason => $rights_log_data->{reason},
+      source => $rights_log_data->{source},
+      gfv_count => $rights_log_data->{gfv_count}
+    };
+  }
+  $sth->finish;
+  return $updates;
+}
+
+# Extract reversions_from_gfv data into e-mail report
+# Optional date_string keyword arg is for testing
+sub reversions_from_gfv_report {
+  my $self       = shift;
+  my $reversions = shift;
+  my %args       = @_;
+
+  my $date_string = $args{date_string} || strftime($REPORT_TIME_FORMAT, localtime);
+  my $report = sprintf "%d volumes reverted from pdus/gfv at $date_string\n\n", scalar @$reversions;
+  my $prior_section = "Has prior GFV status\n\n";
+  my $no_prior_section = "No prior GFV status\n\n";
+  foreach my $reversion (@$reversions) {
+    # There should be at least one GFV (the one we are reverting from).
+    # Anything more than that counts as prior GFV status.
+    if ($reversion->{gfv_count} > 1) {
+      $prior_section .= "$reversion->{namespace}.$reversion->{id}\n";
+    } else {
+      $no_prior_section .= "$reversion->{namespace}.$reversion->{id}\n";
+    }
+  }
+  $report .= $prior_section . "\n";
+  $report .= $no_prior_section;
+  return $report;
+}
+
+sub write_reversion_from_gfv {
+  my $self      = shift;
+  my $reversion = shift;
+
+  $self->{write_reversion_from_gfv_sth}->execute(
+    $reversion->{attr},
+    $reversion->{reason},
+    $reversion->{namespace},
+    $reversion->{id}
+  );
+}
+
+# Returns data from the most recent non-gfv entry in rights_log,
+# plus a count of */gfv entries (including the one we are reverting from)
+# e.g., { attr => 5, reason => 8, source => 1, gfv_count => 1 }
+sub _rights_log_data {
+  my $self      = shift;
+  my $namespace = shift;
+  my $id        = shift;
+
+  my $rights_log_data = { gfv_count => 0 };
+  my $sth = $self->{select_rights_log_sth};
+  $sth->execute($namespace, $id) or die $sth->errstr;
+  while (my $row = $sth->fetch) {
+    my ($attr, $reason, $source) = @$row;
+    if ($reason == $GFV_REASON_ID) {
+      $rights_log_data->{gfv_count}++;
+    } elsif (!defined $rights_log_data->{attr}) {
+      $rights_log_data->{attr} = $attr;
+      $rights_log_data->{reason} = $reason;
+      $rights_log_data->{source} = $source;
+    }
+  }
+  return $rights_log_data;
+}
+
+1;

--- a/t/grin_gfv.t
+++ b/t/grin_gfv.t
@@ -1,0 +1,181 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use utf8;
+
+use Data::Dumper;
+use POSIX qw(strftime);
+use Test::More;
+
+use lib "$ENV{ROOTDIR}/perl_lib";
+use Database;
+use grin_gfv;
+
+my $dbh = Database::get_rights_rw_dbh;
+
+sub load_test_fixtures {
+  my $fixture_data = shift;
+
+  my $rights_current_sql = 'INSERT INTO rights_current (namespace, id, attr, reason, source, access_profile) VALUES (?, ?, ?, ?, 1, 1)';
+  # For reversion, create a matching rights_log entry
+  my $rights_log_sql = 'INSERT INTO rights_log (namespace, id, attr, reason, source, access_profile) VALUES (?, ?, ?, ?, 1, 1)';
+  # Old rights to revert to and old VIEW_FULL cases to count
+  my $old_rights_log_sql = <<~'SQL';
+    INSERT INTO rights_log (namespace, id, attr, reason, source, access_profile, time)
+    VALUES (?, ?, ?, ?, 1, 1, ?)
+  SQL
+  my $feed_grin_sql = 'INSERT INTO ht.feed_grin (namespace, id, viewability, claimed) VALUES (?, ?, ?, ?)';
+  my $rights_current_sth = $dbh->prepare($rights_current_sql);
+  my $rights_log_sth = $dbh->prepare($rights_log_sql);
+  my $old_rights_log_sth = $dbh->prepare($old_rights_log_sql);
+  my $feed_grin_sth = $dbh->prepare($feed_grin_sql);
+  foreach my $fixture (@$fixture_data) {
+    my ($namespace, $id, $attr, $reason, $viewability, $claimed, $logs) = @$fixture;
+    $rights_current_sth->execute($namespace, $id, $attr, $reason);
+    $rights_log_sth->execute($namespace, $id, $attr, $reason);
+    # Insert an old ic/bib so we have something to revert to
+    $old_rights_log_sth->execute($namespace, $id, 2, 1, '2021-01-01 00:00:00');
+    $feed_grin_sth->execute($namespace, $id, $viewability, $claimed);
+    # Optionally insert some old pdus/gfv entries so we can count them
+    foreach my $n (1..$logs) {
+      my $date = "2020-01-0$n 00:00:00";
+      $old_rights_log_sth->execute($namespace, $id, 9, 12, $date);
+    }
+  }
+}
+
+sub unload_test_fixtures {
+  $dbh->prepare('DELETE FROM rights_current WHERE namespace IN ("gfvtest","keio")')->execute;
+  $dbh->prepare('DELETE FROM rights_log WHERE namespace IN ("gfvtest","keio")')->execute;
+  $dbh->prepare('DELETE FROM ht.feed_grin WHERE namespace IN ("gfvtest","keio")')->execute;
+}
+
+# Clean up any previously failed tests
+unload_test_fixtures;
+
+# Qualifies if ic/und and bib and VIEW_FULL and not claimed
+my $updates_test_fixtures = [
+  # namespace id             attr (ic=2 und=5) reason (bib=1) viewability  claimed  logs comment
+  ['gfvtest', 'ic',          2,                1,             'VIEW_FULL', 'false', 0,   'ic included'],
+  ['gfvtest', 'und',         5,                1,             'VIEW_FULL', 'false', 0,   'und included'],
+  ['gfvtest', 'pd',          1,                1,             'VIEW_FULL', 'false', 0,   'pd/* excluded'],
+  ['gfvtest', 'nfi',         5,                8,             'VIEW_FULL', 'false', 0,   '*/nfi excluded'],
+  ['gfvtest', 'nonviewable', 2,                1,             '',          'false', 0,   'viewability != VIEW_FULL excluded'],
+  ['gfvtest', 'claimed',     2,                1,             'VIEW_FULL', 'true',  0,   'claimed=true excluded'],
+  ['keio',    'keio',        2,                1,             'VIEW_FULL', 'false', 0,   'keio excluded'],
+];
+
+subtest "updates_to_gfv" => sub {
+  my $err;
+  load_test_fixtures($updates_test_fixtures);
+  my $grin_gfv = grin_gfv->new;
+  my $updates = $grin_gfv->updates_to_gfv;
+  my $expected = [
+    {
+      'attr'      => 'ic',
+      'id'        => 'ic',
+      'namespace' => 'gfvtest'
+    },
+    {
+      'attr'      => 'und',
+      'id'        => 'und',
+      'namespace' => 'gfvtest'
+    }
+  ];
+  unload_test_fixtures;
+  is_deeply($updates, $expected);
+};
+
+subtest 'updates_to_gfv_report' => sub {
+  load_test_fixtures($updates_test_fixtures);
+  my $grin_gfv = grin_gfv->new;
+  my $date_string = strftime($grin_gfv::REPORT_TIME_FORMAT, localtime);
+  my $updates = $grin_gfv->updates_to_gfv;
+  my $report = $grin_gfv->updates_to_gfv_report($updates, date_string => $date_string);
+  my $expected = <<~REPORT;
+  2 volumes set to pdus/gfv at $date_string
+
+  IC
+
+  gfvtest.ic
+
+  UND
+
+  gfvtest.und
+  REPORT
+  unload_test_fixtures;
+  is($report, $expected);
+};
+
+
+# Qualifies if gfv and (not VIEW_FULL or claimed or keio)
+# old_logs is in addition to the rights we're reverting from so the result will be old_logs + 1 for gfv_count
+my $reversions_test_fixtures = [
+  # namespace id             attr (pdus=9) reason (gfv=12) viewability  claimed old_logs comment
+  ['gfvtest', 'bib',         9,                1,          'VIEW_FULL', 'false', 0,      'non-gfv excluded'],
+  ['gfvtest', 'nonviewable', 9,                12,         '',          'false', 0,      'viewability != VIEW_FULL included'],
+  ['gfvtest', 'claimed',     9,                12,         'VIEW_FULL', 'true',  1,      'claimed=true included'],
+  ['keio',    'keio',        9,                12,         'VIEW_FULL', 'false', 2,      'keio included'],
+];
+
+subtest "reversions_from_gfv" => sub {
+  load_test_fixtures($reversions_test_fixtures);
+  my $grin_gfv = grin_gfv->new;
+  my $reversions = $grin_gfv->reversions_from_gfv;
+  my $expected = [
+    {
+      'attr'      => 2,
+      'gfv_count' => 2,
+      'id'        => 'claimed',
+      'namespace' => 'gfvtest',
+      'reason'    => 1,
+      'source'    => 1
+    },
+    {
+      'attr'      => 2,
+      'gfv_count' => 1,
+      'id'        => 'nonviewable',
+      'namespace' => 'gfvtest',
+      'reason'    => 1,
+      'source'    => 1
+    },
+    {
+      'attr'      => 2,
+      'gfv_count' => 3,
+      'id'        => 'keio',
+      'namespace' => 'keio',
+      'reason'    => 1,
+      'source'    => 1
+    }
+  ];
+  unload_test_fixtures;
+  is_deeply($reversions, $expected);
+};
+
+subtest 'reversions_from_gfv_report' => sub {
+  load_test_fixtures($reversions_test_fixtures);
+  my $grin_gfv = grin_gfv->new;
+  my $date_string = strftime($grin_gfv::REPORT_TIME_FORMAT, localtime);
+  my $reversions = $grin_gfv->reversions_from_gfv;
+  my $report = $grin_gfv->reversions_from_gfv_report($reversions, date_string => $date_string);
+  my $expected = <<~REPORT;
+  3 volumes reverted from pdus/gfv at $date_string
+
+  Has prior GFV status
+
+  gfvtest.claimed
+  keio.keio
+
+  No prior GFV status
+
+  gfvtest.nonviewable
+  REPORT
+  unload_test_fixtures;
+  is($report, $expected);
+};
+
+done_testing;
+
+__END__
+


### PR DESCRIPTION
- Add `grin_gfv` Perl module which does most of the heavy lifting.
- Add tests for most of the exposed functionality
  - FIXME: still need tests for `write_update_to_gfv` and `write_reversion_from_gfv`
- Use experimental version of db-image with `feed_*` tables added
  - FIXME: can we remove `sql/ingest.sql` so we don't have to maintain them here?
- Updated `bin/grin_gfv.pl` to `bin/new_grin_gfv.pl`
  - TODO run some side by side comparisons against actual data (with `noop` flag and the dangerous stuff excised)
  - The new one will replace the old